### PR TITLE
refactor uuid function into more readable form

### DIFF
--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,12 +1,39 @@
+import { intRangeWithEngine } from "./int-range.js";
 import { Engine, defaultEngine } from "./utils.js"
 
 const uuid = (engine: Engine = defaultEngine): string => {
   // Credit @Alexey Silin from https://gist.github.com/1308368
-  let a: any = ''
-  let b: any = ''
-  // eslint-disable-next-line
-  for (b = a = ''; a++ < 36; b += ~a % 5 | a * 3 & 4 ? (a ^ 15 ? 8 ^ engine() * (a ^ 20 ? 16 : 4) : 4).toString(16) : '-') { }
-  return b
+	// Creates a random v4 UUID of the form xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx,
+	// where each x is a random hexadecimal digit from 0 to f, and y is a random
+	// hexadecimal digit from 8 to b.
+	const randomRange = intRangeWithEngine(engine)
+	const defaultGenerator = (): string => randomRange(0, 15).toString(16)
+	const groups: object[] = [
+		{ length: 8 },
+		{ length: 4 },
+		{
+			length: 4,
+			generator: (index: number) => index === 0 ? 4 : defaultGenerator()
+		},
+		{
+			length: 4,
+			generator: (index: number) =>
+				(index === 0 ? randomRange(8, 11).toString(16) : defaultGenerator())
+		},
+		{ length: 12 }
+	];
+	return groups.map(
+		({ length, generator }: any) => {
+			const group: string[] = [];
+			for (let index = 0; index < length; index++) {
+				group.push(generator !== undefined
+					? generator(index)
+					: defaultGenerator()
+				)
+			}
+			return group.join('')
+		}
+	).join('-')
 }
 
 const uuidWithEngine = (engine: Engine = defaultEngine) => {


### PR DESCRIPTION
According to the following statement from the typescript migration pull request

> I think a future PR should refactor the uuid function inside uuid.ts. Code golf isn’t very readable, and it isn’t friendly with typings or linters either.

this could be a first approach to create a more readable form of the function.  
Implementation is realized by creating an array of the 5 groups of a UUID, using their specified individual lengths (8-4-4-4-12) and setting the two particular digits to their specified values (or range, respectively).

The array creation of each group could be realized more compact using `Array.from`, but that would make the transpiler angry, as it's an ES2015 feature and not available atm.

![image](https://github.com/ChrisCavs/aimless.js/assets/262436/ebb4ae01-d693-47a6-856a-6e0131c0bab9)

Besides that, the linter warns about using `any` in the `groups` array's map functor. Any info about how to handle that better would be appreciated (I was somehow hesitant to declare an Interface or sth like that just for that single use).