### PR TITLE
Correct types for const arrays

### DIFF
--- a/src/one-of.ts
+++ b/src/one-of.ts
@@ -1,12 +1,12 @@
 import { intRange } from './int-range'
 import { Engine, defaultEngine } from './utils'
 
-const oneOf = <T>(arr: T[], engine: Engine = defaultEngine): T => {
+const oneOf = <T>(arr: T[] | readonly T[], engine: Engine = defaultEngine): T => {
   return arr[intRange(0, arr.length - 1, engine)]
 }
 
 const oneOfWithEngine = <T>(engine: Engine = defaultEngine) => {
-  return (arr: T[]) => oneOf(arr, engine)
+  return (arr: T[] | readonly T[]) => oneOf(arr, engine)
 }
 
 export {


### PR DESCRIPTION
I wrote a similar function to retrieve a random element from an array, but I encountered a problem when I didn't consider const arrays. With certain TypeScript settings, it even throws an error. However, even if it doesn't, it's still better to specify a readonly array so that the return type is correctly parsed.

TypeScript can be tricky sometimes.

<details>
<summary>Examples</summary>

![image](https://github.com/ChrisCavs/aimless.js/assets/47776594/a48c9d6e-f126-4e81-8aca-3038fbeeb258)
![image](https://github.com/ChrisCavs/aimless.js/assets/47776594/8c6a767a-1e0a-4337-8be2-94afe75446ad).
</details>

<details>
<summary>PS</summary>

Also, is there any particular reason why you don't use a shorthand arrow function like this?
```js
const oneOf = <T>(arr: T[] | readonly T[], engine: Engine = defaultEngine): T =>
   arr[intRange(0, arr.length - 1, engine)];
```

I couldn't find any ESLint rules regarding this.
</details>

