### PR TITLE
Make `weighted`'s TypeScript signature generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ const id = uuid()
 console.log(id) // ef486db4-7f49-43b3-a1ea-b0e0a22bc944
 ```
 
-### weighted(numbers, weights, engine)
+### weighted(array, weights, engine)
 
-Returns one of the `numbers` provided, biased towards the corresponding `weights` provided.  `numbers` can include floats.
+Returns an item from the provided array, biased towards the corresponding `weights`.
 
 ```es6
 const weightedDiceRoll = weighted(
@@ -233,7 +233,7 @@ const weightedDiceRoll = weighted(
 
 If you have any ideas for the project, please [open an issue](https://github.com/ChrisCavs/aimless.js/issues).  I monitor issues frequently and it is a great place for active discussion on new features, refactors, etc.  Even if your idea is half-baked, it may well be worth opening an issue and starting a discussion!
 
-If you'd like, you can also open a [pull request](https://github.com/ChrisCavs/aimless.js/pulls). I am happy to review your code or branch off of it. However, please note that I am unlikely to merge code directly into aimless.js due to code quality / copywrite concerns.  If you're just tooling around with an idea, an [issue](https://github.com/ChrisCavs/aimless.js/issues) might have more success.
+If you'd like, you can also open a [pull request](https://github.com/ChrisCavs/aimless.js/pulls). I am happy to review your code or branch off of it. However, please note that I am unlikely to merge code directly into aimless.js due to code quality / copyright concerns.  If you're just tooling around with an idea, an [issue](https://github.com/ChrisCavs/aimless.js/issues) might have more success.
 
 ## Browser Support
 

--- a/src/weighted.ts
+++ b/src/weighted.ts
@@ -1,8 +1,8 @@
 import { Engine, defaultEngine } from "./utils"
 
-const weighted = (nums: number[], weights: number[], engine: Engine = defaultEngine): number => {
-  if (nums.length !== weights.length) {
-    throw new Error('Every provided number must have a corresponding weight.')
+const weighted = <T>(array: T[] | readonly T[], weights: number[], engine: Engine = defaultEngine): T => {
+  if (array.length !== weights.length) {
+    throw new Error('Every provided item must have a corresponding weight.')
   }
 
   const totalWeight = weights.reduce(
@@ -14,7 +14,7 @@ const weighted = (nums: number[], weights: number[], engine: Engine = defaultEng
   let cumulativeWeight = 0
   let selectedIndex = 0
 
-  for (let i = 0; i < nums.length; i++) {
+  for (let i = 0; i < array.length; i++) {
     cumulativeWeight += weights[i]
 
     if (rand < cumulativeWeight) {
@@ -23,11 +23,11 @@ const weighted = (nums: number[], weights: number[], engine: Engine = defaultEng
     }
   }
 
-  return nums[selectedIndex]
+  return array[selectedIndex]
 }
 
-const weightWithEngine = (engine = defaultEngine) => {
-  return (nums: number[], weights: number[]) => weighted(nums, weights, engine)
+const weightWithEngine = <T>(engine = defaultEngine) => {
+  return (array: T[] | readonly T[], weights: number[]) => weighted(array, weights, engine)
 }
 
 export {


### PR DESCRIPTION
This pull request updates `weighted`'s TypeScript signature to accept other types of arrays.

`Weighted` just returns a random item from the given array and does not require it to be an array of numbers. I've found this function to be quite useful when selecting from non-numerical arrays.

<sup>(This change is too minor to be copyrightable, but to alleviate any concerns, I assign all copyright to ChrisCavs)</sup>