### PR TITLE
fix: correct import target file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,14 @@
   "main": "dist/aimless.js",
   "module": "dist/aimless.module.js",
   "types": "dist/aimless.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/aimless.d.ts",
+      "import": "./dist/aimless.module.js",
+      "require": "./dist/aimless.js"
+    },
+    "./*": "./*"
+  },
   "license": "MIT",
   "repository": "ChrisCavs/aimless.js",
   "author": {


### PR DESCRIPTION
In some cases, `import` cannot correctly import from the `aimless.module.js` file.

```
ERROR The requested module 'file://.../node_modules/aimless.js/dist/aimless.js' does not provide an export named 'bool'

  import { bool } from '.../node_modules/aimless.js/dist/aimless.js';
```

---

link #6